### PR TITLE
Fixed drops to zeroes

### DIFF
--- a/app/src/main/java/de/uni_osnabrueck/ikw/eegdroid/BluetoothLeService.java
+++ b/app/src/main/java/de/uni_osnabrueck/ikw/eegdroid/BluetoothLeService.java
@@ -32,6 +32,8 @@ import android.os.Binder;
 import android.os.IBinder;
 import android.util.Log;
 
+import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -127,6 +129,9 @@ public class BluetoothLeService extends Service {
         final Intent intent = new Intent(action);
         final byte[] data = characteristic.getValue();
         if (data != null && data.length > 0) {
+            // Temporary log for debugging
+            String datastring = Arrays.toString(data);
+            Log.d(TAG, "Uncompressed bytes:" + datastring);
             //We have to decompress the EEG-Data here. This is done by TraumschreiberService.decompress();
             int[] data_int = TraumschreiberService.decompress(data, newTraumschreiber);
             final StringBuilder stringBuilder = new StringBuilder(data.length);
@@ -137,7 +142,7 @@ public class BluetoothLeService extends Service {
             Log.d(TAG, "Received EEG Signal " + stringBuilder1.toString());
             stringBuilder.append(stringBuilder1.toString());
             intent.putExtra(EXTRA_DATA, data_int);
-            Log.d(TAG, "Received EEG Signal " + stringBuilder.toString());
+            //Log.d(TAG, "Received EEG Signal " + stringBuilder.toString());
         }
         sendBroadcast(intent);
     }

--- a/app/src/main/java/de/uni_osnabrueck/ikw/eegdroid/TraumschreiberService.java
+++ b/app/src/main/java/de/uni_osnabrueck/ikw/eegdroid/TraumschreiberService.java
@@ -48,11 +48,16 @@ public class TraumschreiberService {
 
             return data_ints;
         } else {  // for new Traumschreiber
-            int packet_id = data_bytes[0] >> 4;
+            // int packet_id = data_bytes[0] >> 4; -- not used for now.
             int[] data_ints = new int[6];
+            // value of channel n is encoded by 3 bytes placed at positions 3n+1, 3n+2 and 3n+3 in data_bytes
             for (int channel = 0; channel < 6; channel++) {
                 if (data_bytes.length >= (channel + 1) * 3 + 1) {
-                    data_ints[channel] = (data_bytes[channel * 3 + 1] << 16) | (data_bytes[channel * 3 + 2] << 8) | data_bytes[channel * 3 + 3];
+                    // the following three bytes are converted from signed to unsigned through '& 0xff'
+                    int byte1 = data_bytes[channel * 3 + 1] & 0xff;
+                    int byte2 = data_bytes[channel * 3 + 2] & 0xff;
+                    int byte3 = data_bytes[channel * 3 + 3] & 0xff;
+                    data_ints[channel] = byte1 << 16 | byte2 << 8 | byte3;
                 }
             }
             return data_ints;


### PR DESCRIPTION
The issue was that the bytes received from the Traumschreiber were treated as signed bytes. This created false values to result from the byteshift operations in Traumschreiberservice. The fix was to convert the signed bytes to unsigned bytes within the TraumschreiberService before the byteshift operations take place. 

Please exclude BluetoothLeService.java form this pull request.